### PR TITLE
Hotfix: Fix mismatched text color to current theme + Use OBR.theme to set the UI theme

### DIFF
--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -15,5 +15,8 @@ export const darkTheme = createTheme({
         primary: {
             main: "#BB99FF",
         },
+        text: {
+            primary: "#FFFFFF",
+        },
     },
 });

--- a/src/index.css
+++ b/src/index.css
@@ -2,9 +2,6 @@
     font-family: Roboto, Helvetica, Arial, sans-serif;
     line-height: 1.5;
     font-weight: 400;
-
-    color: white;
-
     font-synthesis: none;
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,21 +11,25 @@ import NewSpellModal from "./views/NewSpellModal.tsx";
 import SpellSelectionPopover from "./views/SpellSelectionPopover.tsx";
 import Tutorials from "./views/Tutorials.tsx";
 import { createRoot } from "react-dom/client";
-import { ThemeProvider, useMediaQuery } from "@mui/material";
+import { Paper, ThemeProvider, useMediaQuery } from "@mui/material";
 import { darkTheme, lightTheme } from "./config/theme.ts";
 import OBR from "@owlbear-rodeo/sdk";
 
 // eslint-disable-next-line react-refresh/only-export-components
 function ExtensionMultiplexer() {
     const [searchParams] = useSearchParams();
-    const [themeMode, setThemeMode] = useState<"DARK" | "LIGHT">("LIGHT");
+    const [themeMode, setThemeMode] = useState<"DARK" | "LIGHT">("DARK");
 
     useEffect(() => {
         // Fetch the theme mode from OBR and set it
         OBR.theme.getTheme().then((theme) => {
             setThemeMode(theme.mode);
         });
-    }, []);
+
+        OBR.theme.onChange((theme) => {
+            setThemeMode(theme.mode);
+        });
+    }, [searchParams]);
 
     const children = useMemo(() => {
         if (searchParams.get("obrref")) {
@@ -34,17 +38,19 @@ function ExtensionMultiplexer() {
                     <ThemeProvider
                         theme={themeMode === "DARK" ? darkTheme : lightTheme}
                     >
-                        <Routes>
-                            <Route index element={<Main />} />
-                            <Route
-                                path="spell-selection-popover"
-                                element={<SpellSelectionPopover />}
-                            />
-                            <Route
-                                path="new-spell-modal/:spellID?"
-                                element={<NewSpellModal />}
-                            />
-                        </Routes>
+                        <Paper sx={{ backgroundColor: "transparent" }}>
+                            <Routes>
+                                <Route index element={<Main />} />
+                                <Route
+                                    path="spell-selection-popover"
+                                    element={<SpellSelectionPopover />}
+                                />
+                                <Route
+                                    path="new-spell-modal/:spellID?"
+                                    element={<NewSpellModal />}
+                                />
+                            </Routes>
+                        </Paper>
                     </ThemeProvider>
                 </BaseOBRProvider>
             );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,7 @@
 import "./index.css";
 
 import { BrowserRouter, Route, Routes, useSearchParams } from "react-router";
-import { StrictMode, useMemo } from "react";
+import { StrictMode, useEffect, useMemo, useState } from "react";
 
 import { BaseOBRProvider } from "./react-obr/providers/BaseOBRProvider.tsx";
 import Docs from "./views/Docs.tsx";
@@ -13,17 +13,26 @@ import Tutorials from "./views/Tutorials.tsx";
 import { createRoot } from "react-dom/client";
 import { ThemeProvider, useMediaQuery } from "@mui/material";
 import { darkTheme, lightTheme } from "./config/theme.ts";
+import OBR from "@owlbear-rodeo/sdk";
 
 // eslint-disable-next-line react-refresh/only-export-components
 function ExtensionMultiplexer() {
     const [searchParams] = useSearchParams();
-    const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
+    const [themeMode, setThemeMode] = useState<"DARK" | "LIGHT">("LIGHT");
+
+    useEffect(() => {
+        // Fetch the theme mode from OBR and set it
+        OBR.theme.getTheme().then((theme) => {
+            setThemeMode(theme.mode);
+        });
+    }, []);
+
     const children = useMemo(() => {
         if (searchParams.get("obrref")) {
             return (
                 <BaseOBRProvider>
                     <ThemeProvider
-                        theme={prefersDarkMode ? darkTheme : lightTheme}
+                        theme={themeMode === "DARK" ? darkTheme : lightTheme}
                     >
                         <Routes>
                             <Route index element={<Main />} />
@@ -47,7 +56,8 @@ function ExtensionMultiplexer() {
                 <Route path="listings" element={<Listings />} />
             </Routes>
         );
-    }, [prefersDarkMode, searchParams]);
+    }, [searchParams, themeMode]);
+
     return children;
 }
 


### PR DESCRIPTION
- Fixed the issue where the text is based on the user's system theme instead of the selected OBR theme.
- This should support users who are now using OBR in light mode as well.


Light Mode:
![image](https://github.com/user-attachments/assets/6a9a0c08-119e-4f9d-969d-f554770a229a)

Dark Mode:
![image](https://github.com/user-attachments/assets/7538e3d4-b250-4f68-81d0-2e0b9c768b10)
