### PR TITLE
Fix: theme config and set up + other improvements

### DIFF
--- a/src/components/CustomSpells.css
+++ b/src/components/CustomSpells.css
@@ -71,10 +71,19 @@
     width: 60vw;
 }
 
+
 .modal-content.fade-out {
     animation: fadeOut 0.3s ease-in forwards;
 }
 
+/* TODO: Update the modal-content text color once modal component has been migrated to MUI */
+.modal-content p{
+    color: white;
+}
+
+.modal-content .MuiTypography-root {
+    color: white
+}
 /* Fade-in animation */
 @keyframes fadeIn {
     from {

--- a/src/components/SpellBook.tsx
+++ b/src/components/SpellBook.tsx
@@ -289,12 +289,7 @@ export default function SpellBook() {
                 )}
             </Box>
             {Object.entries(groups).map(([groupName, spells], index) => (
-                <Accordion
-                    variant="outlined"
-                    defaultExpanded
-                    sx={{ backgroundColor: "transparent" }}
-                    key={index}
-                >
+                <Accordion variant="outlined" defaultExpanded key={index}>
                     <AccordionSummary
                         sx={{
                             "&.Mui-expanded": {
@@ -443,7 +438,6 @@ export default function SpellBook() {
                     </span>
                 </Typography>
             )}
-
             <ReactModal
                 isOpen={modalOpened === "create-spell-group"}
                 onRequestClose={closeModal}
@@ -481,9 +475,13 @@ export default function SpellBook() {
                 className={`modal-content ${isModalClosing ? "fade-out" : ""}`}
                 appElement={mainDiv.current!}
             >
-                <p className="title" style={{ display: "block" }}>
+                <Typography
+                    variant="h6"
+                    className="title"
+                    style={{ display: "block" }}
+                >
                     Edit spell group name
-                </p>
+                </Typography>
                 <p style={{ textAlign: "left" }}>
                     Please choose a new name for this spell group:
                 </p>

--- a/src/components/SpellDetails/SpellBanner.tsx
+++ b/src/components/SpellDetails/SpellBanner.tsx
@@ -164,7 +164,6 @@ export default function SpellBanner({
                             <span
                                 className="title"
                                 style={{
-                                    color: "white",
                                     padding: "0.5rem",
                                     borderRadius: "4px",
                                     display: "block",

--- a/src/components/SpellDetails/SpellBanner.tsx
+++ b/src/components/SpellDetails/SpellBanner.tsx
@@ -128,74 +128,73 @@ export default function SpellBanner({
                 backgroundColor: "transparent",
             }}
         >
-            <CardContent sx={{ flex: "1 0 auto", p: 0 }}>
-                {!selectedSpell ? (
+            {!selectedSpell ? (
+                <CardContent sx={{ p: 0, pt: 1.5 }}>
                     <Typography variant="body2" sx={{ m: 1, mb: 0 }}>
                         No active spells. Select one from the spellbook! 🧙‍♂️🔥
                     </Typography>
-                ) : (
-                    <>
-                        <div>
-                            <Box
+                </CardContent>
+            ) : (
+                <>
+                    <Box
+                        sx={{
+                            display: "flex",
+                            alignItems: "center",
+                            // backgroundImage: `url(${ASSET_LOCATION}/${selectedSpell.thumbnail})`,
+                            backgroundSize: "cover",
+                            backgroundPosition: "center",
+                            padding: "0.5rem",
+                            justifyContent: "space-between",
+                            width: "100%",
+                        }}
+                    >
+                        <Box
+                            sx={{
+                                display: "flex",
+                                alignItems: "center",
+                            }}
+                        >
+                            <img
+                                src={`${ASSET_LOCATION}/${selectedSpell.thumbnail}`}
                                 style={{
-                                    display: "flex",
-                                    alignItems: "center",
-                                    // backgroundImage: `url(${ASSET_LOCATION}/${selectedSpell.thumbnail})`,
-                                    backgroundSize: "cover",
-                                    backgroundPosition: "center",
+                                    width: "42px",
+                                    height: "42px",
+                                }}
+                            />
+                            <span
+                                className="title"
+                                style={{
+                                    color: "white",
                                     padding: "0.5rem",
-                                    justifyContent: "space-between",
+                                    borderRadius: "4px",
+                                    display: "block",
+                                    // flexDirection: "column",
                                 }}
                             >
-                                <Box
-                                    sx={{
-                                        display: "flex",
-                                        alignItems: "center",
-                                    }}
-                                >
-                                    <img
-                                        src={`${ASSET_LOCATION}/${selectedSpell.thumbnail}`}
-                                        style={{
-                                            width: "42px",
-                                            height: "42px",
-                                        }}
-                                    />
-                                    <span
-                                        className="title"
-                                        style={{
-                                            color: "white",
-                                            padding: "0.5rem",
-                                            borderRadius: "4px",
-                                            display: "block",
-                                            // flexDirection: "column",
-                                        }}
-                                    >
-                                        {selectedSpell.name}
-                                    </span>
-                                </Box>
-                                <Box
-                                    sx={{
-                                        display: "flex",
-                                        // flexDirection: "column",
-                                        justifyContent: "center",
-                                        alignItems: "center",
-                                        gap: "0.25rem",
-                                        ml: "0.5rem",
-                                        mr: "1rem",
-                                    }}
-                                >
-                                    <Tooltip title="Click for more spell details">
-                                        {renderSpellMode(
-                                            selectedSpell.replicate!,
-                                            selectedSpell.minTargets
-                                        )}
-                                    </Tooltip>
-                                </Box>
-                            </Box>
-                        </div>
-                    </>
-                )}
-            </CardContent>
+                                {selectedSpell.name}
+                            </span>
+                        </Box>
+                        <Box
+                            sx={{
+                                display: "flex",
+                                // flexDirection: "column",
+                                justifyContent: "center",
+                                alignItems: "center",
+                                gap: "0.25rem",
+                                ml: "0.5rem",
+                                mr: "1rem",
+                            }}
+                        >
+                            <Tooltip title="Click for more spell details">
+                                {renderSpellMode(
+                                    selectedSpell.replicate!,
+                                    selectedSpell.minTargets
+                                )}
+                            </Tooltip>
+                        </Box>
+                    </Box>
+                </>
+            )}
         </Card>
     );
 }

--- a/src/config/theme.ts
+++ b/src/config/theme.ts
@@ -6,6 +6,10 @@ export const lightTheme = createTheme({
         primary: {
             main: "#BB99FF",
         },
+        background: {
+            default: "transparent",
+            paper: "transparent",
+        },
     },
 });
 
@@ -15,8 +19,9 @@ export const darkTheme = createTheme({
         primary: {
             main: "#BB99FF",
         },
-        text: {
-            primary: "#FFFFFF",
+        background: {
+            default: "transparent",
+            paper: "transparent",
         },
     },
 });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,7 +11,7 @@ import NewSpellModal from "./views/NewSpellModal.tsx";
 import SpellSelectionPopover from "./views/SpellSelectionPopover.tsx";
 import Tutorials from "./views/Tutorials.tsx";
 import { createRoot } from "react-dom/client";
-import { Paper, ThemeProvider, useMediaQuery } from "@mui/material";
+import { Box, CssBaseline, ThemeProvider } from "@mui/material";
 import { darkTheme, lightTheme } from "./config/theme.ts";
 import OBR from "@owlbear-rodeo/sdk";
 
@@ -21,14 +21,18 @@ function ExtensionMultiplexer() {
     const [themeMode, setThemeMode] = useState<"DARK" | "LIGHT">("DARK");
 
     useEffect(() => {
-        // Fetch the theme mode from OBR and set it
-        OBR.theme.getTheme().then((theme) => {
-            setThemeMode(theme.mode);
-        });
-
-        OBR.theme.onChange((theme) => {
-            setThemeMode(theme.mode);
-        });
+        try {
+            OBR.theme.getTheme().then((theme) => {
+                setThemeMode(theme.mode);
+            });
+            OBR.theme.onChange((theme) => {
+                setThemeMode(theme.mode);
+            });
+        } catch (error) {
+            console.log(error);
+            // TODO: Handle the error gracefully
+            // current error: "Uncaught (in promise) Error: Unable to send message: not ready"
+        }
     }, [searchParams]);
 
     const children = useMemo(() => {
@@ -38,7 +42,8 @@ function ExtensionMultiplexer() {
                     <ThemeProvider
                         theme={themeMode === "DARK" ? darkTheme : lightTheme}
                     >
-                        <Paper sx={{ backgroundColor: "transparent" }}>
+                        <CssBaseline />
+                        <Box sx={{ height: "100vh" }}>
                             <Routes>
                                 <Route index element={<Main />} />
                                 <Route
@@ -50,7 +55,7 @@ function ExtensionMultiplexer() {
                                     element={<NewSpellModal />}
                                 />
                             </Routes>
-                        </Paper>
+                        </Box>
                     </ThemeProvider>
                 </BaseOBRProvider>
             );

--- a/src/views/Main.tsx
+++ b/src/views/Main.tsx
@@ -222,7 +222,7 @@ export default function Main() {
                 justifyContent: "space-between",
             }}
         >
-            <Box>
+            <Box sx={{ flexGrow: 1 }}>
                 <Tabs
                     value={selectedTab}
                     sx={{
@@ -258,10 +258,8 @@ export default function Main() {
                         overflow: "auto",
                         height:
                             selectedTab === 0
-                                ? "calc(100vh - 154px)"
-                                : selectedTab === 3
-                                ? "calc(100vh - 100px)"
-                                : "calc(100vh - 88px)", // Adjust the height as needed
+                                ? "calc(100vh - 7.5rem)"
+                                : "calc(100vh - 4rem)", // Adjust the height as needed
                         scrollbarWidth: "thin", // For Firefox
                         "&::-webkit-scrollbar": {
                             width: "8px", // For Chrome, Safari, and Opera
@@ -273,7 +271,7 @@ export default function Main() {
             </Box>
 
             {selectedTab === 0 && (
-                <Box sx={{ maxHeight: "64px", overflow: "hidden" }}>
+                <Box sx={{ overflow: "hidden" }}>
                     <SpellBanner
                         onButtonClick={() => {
                             setSelectedTab(SPELL_DETAIL_TAB);

--- a/src/views/NewSpellModal.css
+++ b/src/views/NewSpellModal.css
@@ -80,6 +80,10 @@
     background-color: rgb(30, 34, 49);
 }
 
+.spell-creation-blueprint-container svg {
+    color: white
+ }
+
 .spell-creation-blueprint-controls > * {
     margin-left: 1rem;
 }
@@ -107,8 +111,6 @@
     min-width: 10rem;
     border-radius: 1rem;
     border: thin solid white;
-
-    background-color: rgb(30, 34, 49);
 
     cursor: pointer;
 }


### PR DESCRIPTION
There a couple of fixes in this PR:

1. Fix incorrectly configured MUI Theme
---
- Text color should now properly match the theme, regardless of implementation via <Typography> or <p>
- Undo the incorrect implementation of adding the <Paper> component at the base level of the app

2. Fix responsive layout of spellbook and inline scrolling
---
- Changed height calculation to REM instead of PX to adjust properly based on screen resolution
- Fix padding layout of spell preview in the spellbook tab (it was off by a few px)

Dark Mode:
![image](https://github.com/user-attachments/assets/b7b61717-b972-456d-bac1-b01ed4041bde)

Light Mode:
![image](https://github.com/user-attachments/assets/57ef342b-777b-4953-a666-3f6b91f1b133)


3. Other fixes
---
- In the previous fix, the Custom Spell modal will sometimes crash due to OBR.getTheme() not error handled. Added a simple catch logic but it only does console.log() for now... until I understand the OBR api better.
- In light mode, the ReactModal will always have a fixed background; I've hardcoded the text within to have a color of white.
- The fields in Blueprint creation page have a dark background both in light and dark mode, but its text is responsive to the theme; I've fixed this potential color mismatch by removing the dark background of the blueprint fields (the borders should be enough)
![image](https://github.com/user-attachments/assets/67b7f92f-6104-473a-b4d4-f4b50c716675)
